### PR TITLE
Only install ca-certificates if inside a container

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -46,9 +46,9 @@ runs:
           SUDO="sudo"
         fi
 
-        # Install ca-certificates only in containers (they often have minimal images)
-        if [ -f /.dockerenv ] || grep -q 'docker\|lxc\|kubepods' /proc/1/cgroup 2>/dev/null; then
-          echo "Running in container, installing ca-certificates..."
+        # Install ca-certificates in Docker containers
+        if [ -f /.dockerenv ]; then
+          echo "Running in Docker, installing ca-certificates..."
           $SUDO apt-get update
           $SUDO apt-get install -y ca-certificates
         fi

--- a/action.yaml
+++ b/action.yaml
@@ -46,10 +46,12 @@ runs:
           SUDO="sudo"
         fi
 
-        # Install ca-certificates (required for latest lets-encrypt certificates)
-        echo "Installing ca-certificates..."
-        $SUDO apt-get update
-        $SUDO apt-get install -y ca-certificates
+        # Install ca-certificates only in containers (they often have minimal images)
+        if [ -f /.dockerenv ] || grep -q 'docker\|lxc\|kubepods' /proc/1/cgroup 2>/dev/null; then
+          echo "Running in container, installing ca-certificates..."
+          $SUDO apt-get update
+          $SUDO apt-get install -y ca-certificates
+        fi
 
         # Configure apt to use cache servers
         # Try new format first (Ubuntu 22.04+), fall back to old format


### PR DESCRIPTION
Our hosts have a modern version of `ca-certificates`, but containers may not.