### PR TITLE
Add pypi-anaconda proxy cache env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,17 +8,19 @@ Currently this action supports the following package managers:
 
 - `pip`
 - `conda`
+- `pypi-anaconda`
 - `apt`
 
 ## Inputs
 
 This action supports the following inputs
 
-| Input          | Type   | Default | Description                               |
-| -------------- | ------ | ------- | ----------------------------------------- |
-| `enable-pip`   | `bool` | `true`  | Setup `pip` to use the proxy as a cache   |
-| `enable-conda` | `bool` | `true`  | Setup `conda` to use the proxy as a cache |
-| `enable-apt`   | `bool` | `false` | Setup `apt` to use the proxy as a cache   |
+| Input                  | Type   | Default | Description                                                                          |
+| ---------------------- | ------ | ------- | ------------------------------------------------------------------------------------ |
+| `enable-pip`           | `bool` | `true`  | Setup `pip` to use the proxy as a cache                                              |
+| `enable-conda`         | `bool` | `true`  | Setup `conda` to use the proxy as a cache                                            |
+| `enable-pypi-anaconda` | `bool` | `true`  | Export the pypi-anaconda proxy cache URL to `NV_GHA_RUNNERS_PYPI_ANACONDA_CACHE_URL` |
+| `enable-apt`           | `bool` | `false` | Setup `apt` to use the proxy as a cache                                              |
 
 ## Example
 

--- a/action.yaml
+++ b/action.yaml
@@ -9,6 +9,10 @@ inputs:
     description: "Setup conda to use the proxy cache"
     required: false
     default: true
+  enable-pypi-anaconda:
+    description: "Export the pypi-anaconda proxy cache URL to NV_GHA_RUNNERS_PYPI_ANACONDA_CACHE_URL"
+    required: false
+    default: true
   enable-apt:
     description: "Setup apt to use the proxy cache"
     required: false
@@ -24,6 +28,10 @@ runs:
     - name: Setup conda to use the proxy cache
       if: ${{ inputs.enable-conda }}
       run: echo "CONDA_CHANNEL_ALIAS=https://conda-cache.local.gha-runners.nvidia.com/" >> "${GITHUB_ENV}"
+      shell: bash
+    - name: Export pypi-anaconda proxy cache URL to NV_GHA_RUNNERS_PYPI_ANACONDA_CACHE_URL
+      if: ${{ inputs.enable-pypi-anaconda }}
+      run: echo "NV_GHA_RUNNERS_PYPI_ANACONDA_CACHE_URL=https://pypi-anaconda-cache.local.gha-runners.nvidia.com/simple" >> "${GITHUB_ENV}"
       shell: bash
     - name: Setup apt to use the proxy cache
       if: ${{ inputs.enable-apt }}


### PR DESCRIPTION
Since teams manage their own PIP_EXTRA_INDEX_URLS, we don't want to override / append to that list.

Instead, expose an environment variable that teams who want to use the proxy-cache can search for and manage themselves.